### PR TITLE
[IMP] education_notebook_observation: New permissions, and new menu o…

### DIFF
--- a/education_notebook_observation/__manifest__.py
+++ b/education_notebook_observation/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Education Notebook Observation",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "depends": [
         "calendar_school",
         "contacts_school",

--- a/education_notebook_observation/i18n/education_notebook_observation.pot
+++ b/education_notebook_observation/i18n/education_notebook_observation.pot
@@ -305,3 +305,15 @@ msgstr ""
 msgid "lines of wizard for generate notebook observations"
 msgstr ""
 
+#. module: education_notebook_observation
+#: model:ir.actions.act_window,name:education_notebook_observation.education_notebook_observation_action
+#: model:ir.ui.menu,name:education_notebook_observation.education_notebook_observation_menu
+msgid "Requested notebook observations"
+msgstr ""
+
+#. module: education_notebook_observation
+#: model:ir.actions.act_window,name:education_notebook_observation.education_notebook_observation_action2
+#: model:ir.ui.menu,name:education_notebook_observation.education_notebook_observation_menu2
+msgid "Notebook observations to make"
+msgstr ""
+

--- a/education_notebook_observation/i18n/es.po
+++ b/education_notebook_observation/i18n/es.po
@@ -335,3 +335,15 @@ msgstr "Usted va a mandar un email a los proforesores solicitando las observacio
 msgid "lines of wizard for generate notebook observations"
 msgstr "Líneas del asistente para generar observaciones cuaderno"
 
+#. module: education_notebook_observation
+#: model:ir.actions.act_window,name:education_notebook_observation.education_notebook_observation_action
+#: model:ir.ui.menu,name:education_notebook_observation.education_notebook_observation_menu
+msgid "Requested notebook observations"
+msgstr "Observaciones de cuaderno solicitadas"
+
+#. module: education_notebook_observation
+#: model:ir.actions.act_window,name:education_notebook_observation.education_notebook_observation_action2
+#: model:ir.ui.menu,name:education_notebook_observation.education_notebook_observation_menu2
+msgid "Notebook observations to make"
+msgstr "Observaciones de cuaderno a realizar"
+

--- a/education_notebook_observation/tests/test_education_notebook_observation.py
+++ b/education_notebook_observation/tests/test_education_notebook_observation.py
@@ -114,7 +114,8 @@ class TestEducationNotebookObservation(TestCalendarSchool):
         observation = calendars[0].calendar_event_notebook_observation_ids[0]
         observation.write({'observations': 'aaaaaaaaaaaaaaaaa'})
         self.assertEqual(observation.state, 'included')
-        domain = [('teacher_id', 'in', [self.teacher.id])]
+        domain = ['&', ('teacher_id', 'in', [self.teacher.id]),
+                  ('state', '=', 'included')]
         res = self.teacher.button_show_notebook_observations()
         self.assertEqual(res.get('domain'), domain)
 

--- a/education_notebook_observation/views/calendar_event_view.xml
+++ b/education_notebook_observation/views/calendar_event_view.xml
@@ -11,11 +11,11 @@
                     <button name="%(action_wiz_generate_notebook_observation)d"
                         string="Generate notebook observations"
                         type="action"
-                        groups="education.education_responsible"/>
+                        groups="education.education_user"/>
                     <button name="%(action_wiz_send_notebook_observation_email)d"
                         string="Send email to teachers requesting notebook observations"
                         type="action"
-                        groups="education.education_responsible"/>
+                        groups="education.education_user"/>
                     <field name="calendar_event_notebook_observation_ids" nolabel="1" >
                         <tree>
                             <field name="observ_date" invisible="1"/>

--- a/education_notebook_observation/views/education_notebook_observation_view.xml
+++ b/education_notebook_observation/views/education_notebook_observation_view.xml
@@ -49,20 +49,30 @@
     </record>
 
     <record id="education_notebook_observation_action" model="ir.actions.act_window">
-        <field name="name">Notebook observations</field>
+        <field name="name">Requested notebook observations</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">education.notebook.observation</field>
         <field name="view_mode">form,tree</field>
         <field name="view_type">form</field>
-        <field name="context">{
-            "hide_numeric": False,
-            "hide_behaviour": False,
-            "hide_calculated": False,
-        }</field>
+        <field name="domain">[('state', '=', 'included')]</field>
         <field name="view_id" ref="education_notebook_observation_view_tree"/>
     </record>
 
     <menuitem id="education_notebook_observation_menu"
               parent="education_evaluation_notebook.education_evaluation_menuitem"
               action="education_notebook_observation_action" />
+
+    <record id="education_notebook_observation_action2" model="ir.actions.act_window">
+        <field name="name">Notebook observations to make</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">education.notebook.observation</field>
+        <field name="view_mode">form,tree</field>
+        <field name="view_type">form</field>
+        <field name="domain">[('state', '=', 'pending')]</field>
+        <field name="view_id" ref="education_notebook_observation_view_tree"/>
+    </record>
+
+    <menuitem id="education_notebook_observation_menu2"
+              parent="education_evaluation_notebook.education_evaluation_menuitem"
+              action="education_notebook_observation_action2" />
 </odoo>


### PR DESCRIPTION
…ption.
1.- Que en reuniones los profes vean la pestaña de "invitaciones".
2.- En pestaña observaciones cuadreno, visibles los botones de generar obserciones, y mandar email.
3.- La opción de menu "Observaciones de cuaderno" pasa a ser "Observaciones de cuaderno solicitadas", y se crea una nuevo menú "Observaciones de cuaderno a realizar".